### PR TITLE
chore: release v0.1.1

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build Coverage
         env:
-            DATABASE_URL: postgresql://postgres:postgres@postgres:55533/postgres
+          DATABASE_URL: postgresql://postgres:postgres@postgres:55533/postgres
         run: cargo tarpaulin --verbose --all-features --include-tests --out lcov
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,5 +67,5 @@ jobs:
 
       - name: Test
         env:
-            DATABASE_URL: postgresql://postgres:postgres@localhost:55532/postgres
+          DATABASE_URL: postgresql://postgres:postgres@localhost:55532/postgres
         run: cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.1.1](https://github.com/arcuru/eidetica/compare/v0.1.0...v0.1.1) - 2024-11-03
+
+### Added
+
+- add ref_count to the Data table
+- adding a 'local' bit to the metadatatable
+- add a settings table on top of metadatatable
+- adding accessor method for searching the metadata
+- adding get_active_entries interface to metadatatable
+- add configurable table name to PostgresMetadataTable
+- add data table for storing file data and tracking file locations
+- Use a blake2b hash instead of data
+- implement SQL database interface for metadata storage
+
+### Fixed
+
+- remove pre-commit from the Taskfile
+
+### Other
+
+- run formatters
+- rename database to datastore
+- poking the coverage workflow
+- updating repo badges
+- fixing coverage workflow
+- adding workflows for CI
+- add helper for code coverage
+- removing leftover debug statements
+- add architectural description of encryption scheme
+- update the flake and run formatting
+- move database into a folder module
+- add initial planned architecture
+- ignoring more files
+- fix git cliff generation
+- install and use git-cliff
+
 ### Documentation
 
 - Install and use git-cliff

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "eidetica"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake2",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eidetica"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Patrick Jackson <patrick@jackson.dev>"]
 readme = "README.md"

--- a/src/datastore/data.rs
+++ b/src/datastore/data.rs
@@ -20,6 +20,12 @@ pub trait DataTable {
     /// Retrieve an entry by its hash
     async fn get_entry(&self, hash: &str) -> Result<Option<DataEntry>, Error>;
 
+    /// Increase the ref_count
+    async fn increase_ref_count(&mut self, hash: &str) -> Result<i32, Error>;
+
+    /// Decrease the ref_count
+    async fn decrease_ref_count(&mut self, hash: &str) -> Result<i32, Error>;
+
     /// Add a device to the list of devices that have this data
     async fn add_device(&mut self, hash: &str, device_id: Uuid) -> Result<(), Error>;
 
@@ -84,6 +90,7 @@ impl PostgresDataTable {
                 r#"
                 CREATE TABLE IF NOT EXISTS data_entries (
                     hash CHAR(67) PRIMARY KEY,
+                    ref_count INT NOT NULL DEFAULT 0,
                     inline_data BYTEA,
                     devices UUID[] NOT NULL DEFAULT '{}',
                     local_path TEXT[] NOT NULL DEFAULT '{}',
@@ -115,14 +122,15 @@ impl DataTable for PostgresDataTable {
         let row = sqlx::query(
             r#"
         INSERT INTO data_entries
-            (hash, inline_data, devices, local_path, s3_path)
+            (hash, ref_count, inline_data, devices, local_path, s3_path)
         VALUES
-            ($1, NULL, ARRAY[]::UUID[], ARRAY[]::TEXT[], ARRAY[]::TEXT[])
+            ($1, 0, NULL, ARRAY[]::UUID[], ARRAY[]::TEXT[], ARRAY[]::TEXT[])
         ON CONFLICT (hash) DO UPDATE SET
             -- Set hash to itself to trigger the RETURNING clause
             hash = EXCLUDED.hash
         RETURNING
             hash,
+            ref_count,
             inline_data,
             devices,
             local_path,
@@ -136,6 +144,7 @@ impl DataTable for PostgresDataTable {
 
         Ok(DataEntry {
             hash: row.get("hash"),
+            ref_count: row.get("ref_count"),
             inline_data: row.get("inline_data"),
             devices: row.get("devices"),
             local_path: row.get("local_path"),
@@ -148,6 +157,7 @@ impl DataTable for PostgresDataTable {
             r#"
             SELECT
                 hash,
+                ref_count,
                 inline_data,
                 devices,
                 local_path,
@@ -165,6 +175,7 @@ impl DataTable for PostgresDataTable {
             Some(row) => {
                 let entry = DataEntry {
                     hash: row.get("hash"),
+                    ref_count: row.get("ref_count"),
                     inline_data: row.get("inline_data"),
                     devices: row.get("devices"),
                     local_path: row.get("local_path"),
@@ -188,12 +199,13 @@ impl DataTable for PostgresDataTable {
         let result = sqlx::query(
             r#"
             INSERT INTO data_entries
-                (hash, inline_data, devices, local_path, s3_path)
+                (hash, ref_count, inline_data, devices, local_path, s3_path)
             VALUES
-                ($1, $2, $3, $4, $5)
+                ($1, $2, $3, $4, $5, $6)
             "#,
         )
         .bind(&entry.hash)
+        .bind(entry.ref_count)
         .bind(entry.inline_data)
         .bind(&entry.devices)
         .bind(&entry.local_path)
@@ -220,6 +232,46 @@ impl DataTable for PostgresDataTable {
             .map_err(|e| Error::Database(Box::new(e)))?;
 
         Ok(())
+    }
+
+    async fn increase_ref_count(&mut self, hash: &str) -> Result<i32, Error> {
+        let row = sqlx::query(
+            r#"
+            UPDATE data_entries
+            SET ref_count = ref_count + 1
+            WHERE hash = $1
+            RETURNING ref_count
+            "#,
+        )
+        .bind(hash)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| Error::Database(Box::new(e)))?;
+
+        match row {
+            Some(row) => Ok(row.get("ref_count")),
+            None => Err(Error::NotFound),
+        }
+    }
+
+    async fn decrease_ref_count(&mut self, hash: &str) -> Result<i32, Error> {
+        let row = sqlx::query(
+            r#"
+            UPDATE data_entries
+            SET ref_count = GREATEST(ref_count - 1, 0)
+            WHERE hash = $1
+            RETURNING ref_count
+            "#,
+        )
+        .bind(hash)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| Error::Database(Box::new(e)))?;
+
+        match row {
+            Some(row) => Ok(row.get("ref_count")),
+            None => Err(Error::NotFound),
+        }
     }
 
     async fn add_inline_data(&mut self, hash: &str, data: Vec<u8>) -> Result<(), Error> {
@@ -409,6 +461,7 @@ mod tests {
 
         let entry = DataEntry {
             hash: generate_hash("test_data".as_bytes()),
+            ref_count: 1,
             inline_data: Some(b"test data".to_vec()),
             devices: vec![Uuid::new_v4()],
             local_path: vec!["local/path/to/file".to_string()],
@@ -434,6 +487,7 @@ mod tests {
 
         let original_entry = DataEntry {
             hash: hash.clone(),
+            ref_count: 1,
             inline_data: Some(b"test data".to_vec()),
             devices: vec![device_id],
             local_path: vec!["local/path/to/file".to_string()],
@@ -471,6 +525,7 @@ mod tests {
 
         // Verify the newly inserted entry has the correct hash and empty fields
         assert_eq!(entry.hash, hash);
+        assert_eq!(entry.ref_count, 0);
         assert!(entry.inline_data.is_none());
         assert!(entry.devices.is_empty());
         assert!(entry.local_path.is_empty());
@@ -484,6 +539,7 @@ mod tests {
 
         // Verify we got back the same entry
         assert_eq!(existing_entry.hash, entry.hash);
+        assert_eq!(existing_entry.ref_count, entry.ref_count);
         assert_eq!(existing_entry.inline_data, entry.inline_data);
         assert_eq!(existing_entry.devices, entry.devices);
         assert_eq!(existing_entry.local_path, entry.local_path);
@@ -601,6 +657,7 @@ mod tests {
         // Create an entry with inline data
         let entry = DataEntry {
             hash: hash.clone(),
+            ref_count: 1,
             inline_data: Some(b"test data".to_vec()),
             devices: vec![],
             local_path: vec![],
@@ -638,6 +695,7 @@ mod tests {
         // Create an entry with paths and device
         let entry = DataEntry {
             hash: hash.clone(),
+            ref_count: 1,
             inline_data: None,
             devices: vec![device_id],
             local_path: vec!["local/path/test.dat".to_string()],
@@ -696,6 +754,7 @@ mod tests {
         // Create an entry with multiple paths
         let entry = DataEntry {
             hash: hash.clone(),
+            ref_count: 1,
             inline_data: None,
             devices: vec![],
             local_path: vec![
@@ -724,5 +783,77 @@ mod tests {
         assert!(table.remove_local_path(&hash, "path2.dat").await.is_ok());
         let entry3 = table.get_entry(&hash).await.unwrap().unwrap();
         assert!(entry3.local_path.is_empty());
+    }
+
+    #[sqlx::test]
+    async fn test_ref_count_operations(pool: PgPool) -> Result<(), Error> {
+        let mut table = PostgresDataTable::from_pool(pool.clone()).await?;
+        let test_hash = "b2_test_hash_ref_count";
+
+        // Insert initial test entry
+        let entry = DataEntry {
+            hash: test_hash.to_string(),
+            ref_count: 0,
+            inline_data: None,
+            devices: vec![],
+            local_path: vec![],
+            s3_path: vec![],
+        };
+        table.create_entry(entry).await?;
+
+        // Test increasing ref_count
+        let count = table.increase_ref_count(test_hash).await?;
+        assert_eq!(count, 1, "First increase should result in ref_count = 1");
+
+        let count = table.increase_ref_count(test_hash).await?;
+        assert_eq!(count, 2, "Second increase should result in ref_count = 2");
+
+        // Test decreasing ref_count
+        let count = table.decrease_ref_count(test_hash).await?;
+        assert_eq!(count, 1, "First decrease should result in ref_count = 1");
+
+        let count = table.decrease_ref_count(test_hash).await?;
+        assert_eq!(count, 0, "Second decrease should result in ref_count = 0");
+
+        // Test that ref_count doesn't go below 0
+        let count = table.decrease_ref_count(test_hash).await?;
+        assert_eq!(count, 0, "ref_count should not go below 0");
+
+        // Test operations on non-existent hash
+        let non_existent = "b2_nonexistent_hash";
+        assert!(matches!(
+            table.increase_ref_count(non_existent).await,
+            Err(Error::NotFound)
+        ));
+        assert!(matches!(
+            table.decrease_ref_count(non_existent).await,
+            Err(Error::NotFound)
+        ));
+
+        // Test concurrent operations
+        let mut handles = vec![];
+        for _ in 0..5 {
+            let pool = pool.clone();
+            let hash = test_hash.to_string();
+            handles.push(tokio::spawn(async move {
+                let mut table = PostgresDataTable::from_pool(pool).await.unwrap();
+                let inc = table.increase_ref_count(&hash).await.unwrap();
+                let dec = table.decrease_ref_count(&hash).await.unwrap();
+                (inc, dec)
+            }));
+        }
+
+        // Wait for all operations to complete and verify counts
+        for handle in handles {
+            let (inc, dec) = handle.await.unwrap();
+            assert!(inc > 0, "Increased count should be positive");
+            assert!(dec >= 0, "Decreased count should not be negative");
+        }
+
+        // Verify final count is 0
+        let final_count = table.decrease_ref_count(test_hash).await?;
+        assert_eq!(final_count, 0, "Final ref_count should be 0");
+
+        Ok(())
     }
 }

--- a/src/datastore/schema.rs
+++ b/src/datastore/schema.rs
@@ -37,6 +37,10 @@ pub struct DataEntry {
     /// Allows for future hash algorithms with different prefixes
     pub hash: String,
 
+    /// Reference Count
+    /// How many metadata entries expect this data
+    pub ref_count: i32, // TODO: I'm not sure how safe this type is...
+
     /// Inline data for small entries
     pub inline_data: Option<Vec<u8>>,
 
@@ -59,6 +63,7 @@ impl DataEntry {
     pub fn new<S: Into<String>>(hash: S) -> Self {
         Self {
             hash: hash.into(),
+            ref_count: 0,
             inline_data: None,
             devices: Vec::new(),
             local_path: Vec::new(),

--- a/src/datastore/store.rs
+++ b/src/datastore/store.rs
@@ -1,0 +1,222 @@
+use data::{DataLocation, DataLocations, DataTable, PostgresDataTable};
+use error::Error;
+use metadata::{MetadataTable, PostgresMetadataTable};
+use schema::MetadataEntry;
+use serde_json::Value;
+use settings::SettingsTable;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Data Store
+///
+/// This is a logical set of data, with it's own device id, metadata table,
+/// settings table, and either a private or shared data table.
+#[allow(dead_code)]
+pub struct DataStore<D: DataTable, M: MetadataTable> {
+    /// Unique identifier for this device
+    device_id: uuid::Uuid,
+    /// Table for storing actual data or references to data
+    data_table: D,
+    /// Table for storing metadata about the data
+    metadata_table: M,
+    /// Table for storing settings for this data store
+    settings_table: SettingsTable<M>,
+}
+
+#[allow(dead_code)]
+impl DataStore<PostgresDataTable, PostgresMetadataTable> {
+    /// Create a new DataStore from a Postgres connection pool
+    ///
+    /// # Arguments
+    /// * `pool` - PostgreSQL connection pool
+    /// * `name` - Name of this data store (used as table prefix)
+    /// * `device_id` - Unique identifier for this device
+    pub async fn from_pool(pool: PgPool, name: &str, device_id: Uuid) -> Result<Self, Error> {
+        // Create the individual tables
+        let metadata_table = PostgresMetadataTable::from_pool(pool.clone(), name).await?;
+        let data_table = PostgresDataTable::from_pool(pool.clone()).await?;
+        let settings_table = SettingsTable::from_postgres(pool, device_id).await?;
+
+        Ok(Self {
+            device_id,
+            data_table,
+            metadata_table,
+            settings_table,
+        })
+    }
+}
+
+#[allow(dead_code)]
+impl<D: DataTable, M: MetadataTable> DataStore<D, M> {
+    /// Store a new piece of data
+    ///
+    /// # Arguments
+    /// * `data` - The raw data to store
+    /// * `metadata` - JSON metadata about the data (type, store name, etc)
+    /// * `parent_id` - Optional parent entry this is updating
+    ///
+    /// # Returns
+    /// The UUID of the newly created entry
+    pub async fn store_data(
+        &mut self,
+        data: Vec<u8>,
+        metadata: Value,
+        parent_id: Option<Uuid>,
+    ) -> Result<Uuid, Error> {
+        unimplemented!();
+    }
+
+    /// Get the history of a piece of data by following its parent chain
+    ///
+    /// Returns a vector of MetadataEntry objects in descending order (newest to oldest).
+    /// Each entry contains:
+    /// - id: The unique identifier for this version
+    /// - device_id: The device that created this version
+    /// - archived: Whether this version is archived
+    /// - parent_id: Reference to the previous version
+    /// - metadata: User-defined metadata for this version
+    /// - data_hash: Reference to the underlying data
+    ///
+    /// # Arguments
+    /// * `id` - UUID of the entry to get history for
+    ///
+    /// # Returns
+    /// Vector of MetadataEntry in descending order (newest to oldest)
+    pub async fn get_history(&self, id: Uuid) -> Result<Vec<MetadataEntry>, Error> {
+        // Use the metadata table's recursive query capability to get the full history
+        self.metadata_table.get_entry_history(id).await
+    }
+
+    /// Mark a piece of data as archived/deleted by creating a new entry that archives the old one
+    ///
+    /// # Arguments
+    /// * `id` - UUID of the entry to archive
+    pub async fn archive(&mut self, id: Uuid) -> Result<(), Error> {
+        // First check if the entry exists and get its metadata
+        let existing_entry = match self.metadata_table.get_entry(id).await? {
+            Some(entry) => entry,
+            None => return Err(Error::NotFound),
+        };
+
+        // Create a new metadata entry that marks this as archived
+        // TODO: I'm not certain this is the right new entry, leaving for now
+        let archive_entry = MetadataEntry {
+            id: Uuid::now_v7(),
+            device_id: self.device_id,
+            // The newly entered entry is _also_ archived...
+            archived: true,
+            parent_id: Some(id),
+            // Preserve the original metadata but add archived flag
+            metadata: {
+                let mut metadata = existing_entry.metadata.clone();
+                if let Value::Object(ref mut map) = metadata {
+                    map.insert("archived".to_string(), Value::Bool(true));
+                }
+                metadata
+            },
+            data_hash: "".to_string(),
+        };
+
+        // Create the new entry - this will automatically archive the parent
+        self.metadata_table.create_entry(archive_entry).await?;
+
+        Ok(())
+    }
+
+    /// Query active entries by metadata conditions
+    ///
+    /// # Arguments
+    /// * `conditions` - JSON metadata conditions to match against
+    /// * `include_archived` - Whether to include archived entries
+    ///
+    /// # Returns
+    /// Vector of matching entries' (id, metadata) pairs
+    pub async fn query_by_metadata(
+        &self,
+        conditions: &Value,
+        include_archived: bool,
+    ) -> Result<Vec<(Uuid, Value)>, Error> {
+        // Use the metadata table's query capability
+        let entries = self
+            .metadata_table
+            .get_entries_by_metadata_conditions(conditions, include_archived)
+            .await?;
+
+        // Convert the entries into the simpler (id, metadata) format for the public API
+        Ok(entries
+            .into_iter()
+            .map(|entry| (entry.id, entry.metadata))
+            .collect())
+    }
+
+    /// Get all locations where a piece of data is stored
+    /// (inline, local paths, S3 paths, other devices)
+    ///
+    /// # Arguments
+    /// * `id` - UUID of the entry to get locations for
+    ///
+    /// # Returns
+    /// The various locations where this data can be found
+    pub async fn get_data_locations(&self, id: Uuid) -> Result<DataLocations, Error> {
+        // First get the metadata entry to get the data hash
+        let entry = match self.metadata_table.get_entry(id).await? {
+            Some(e) => e,
+            None => return Err(Error::NotFound),
+        };
+
+        // Use the hash to get the data entry
+        let data_entry = match self.data_table.get_entry(&entry.data_hash).await? {
+            Some(e) => e,
+            None => return Err(Error::NotFound),
+        };
+
+        // Convert the data entry into our DataLocations struct
+        Ok(DataLocations {
+            inline_data: data_entry.inline_data,
+            s3_paths: data_entry.s3_path,
+            local_paths: data_entry.local_path,
+            devices: data_entry.devices,
+        })
+    }
+
+    /// Add a new storage location for a piece of data
+    ///
+    /// # Arguments
+    /// * `id` - UUID of the entry
+    /// * `location` - The new location to add (S3, local path, or device)
+    pub async fn add_data_location(
+        &mut self,
+        id: Uuid,
+        location: DataLocation,
+    ) -> Result<(), Error> {
+        // First get the metadata entry to get the data hash
+        let entry = match self.metadata_table.get_entry(id).await? {
+            Some(e) => e,
+            None => return Err(Error::NotFound),
+        };
+
+        // Add the location based on its type
+        match location {
+            DataLocation::Inline(data) => {
+                self.data_table
+                    .add_inline_data(&entry.data_hash, data)
+                    .await?;
+            }
+            DataLocation::S3(path) => {
+                self.data_table.add_s3_path(&entry.data_hash, path).await?;
+            }
+            DataLocation::LocalPath(path) => {
+                self.data_table
+                    .add_local_path(&entry.data_hash, path)
+                    .await?;
+            }
+            DataLocation::Device(device_id) => {
+                self.data_table
+                    .add_device(&entry.data_hash, device_id)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## 🤖 New release
* `eidetica`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/arcuru/eidetica/compare/v0.1.0...v0.1.1) - 2024-11-03

### Added

- add ref_count to the Data table
- adding a 'local' bit to the metadatatable
- add a settings table on top of metadatatable
- adding accessor method for searching the metadata
- adding get_active_entries interface to metadatatable
- add configurable table name to PostgresMetadataTable
- add data table for storing file data and tracking file locations
- Use a blake2b hash instead of data
- implement SQL database interface for metadata storage

### Fixed

- remove pre-commit from the Taskfile

### Other

- run formatters
- rename database to datastore
- poking the coverage workflow
- updating repo badges
- fixing coverage workflow
- adding workflows for CI
- add helper for code coverage
- removing leftover debug statements
- add architectural description of encryption scheme
- update the flake and run formatting
- move database into a folder module
- add initial planned architecture
- ignoring more files
- fix git cliff generation
- install and use git-cliff

### Documentation

- Install and use git-cliff
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).